### PR TITLE
Plan and implement ECS milestone

### DIFF
--- a/DevDiary.md
+++ b/DevDiary.md
@@ -10,3 +10,17 @@
 ## 2024-05-29 ExecutorAgent
 - Completed ST1: workspace and crates created.
 - Implemented INI parser and tests. Updated README.
+
+## 2025-07-29 PlannerAgent
+- Reviewed completed Milestone 1.
+- Planned Milestone 2 for ECS architecture and entity manager.
+- Added five new subtasks for ECS scaffolding, manager, spawn helper, tests and documentation.
+- Updated metrics, state hash and taskmap accordingly.
+
+## 2025-07-29 ExecutorAgent
+- Completed ST5: Added ECS module scaffolding with basic World and Component traits.
+- Implemented ST6: entity manager storing components generically.
+- Implemented ST7: added spawn_unit helper.
+- Implemented ST8: added unit tests for entity creation.
+- Implemented ST9: documented ECS usage in README.
+- Milestone 2 completed: ECS can spawn and manage entities.

--- a/README.md
+++ b/README.md
@@ -50,3 +50,17 @@ Unit tests can be executed with:
 cargo test
 ```
 
+## ECS Usage
+The `sage_core` crate now exposes a minimal ECS. Entities are spawned via the
+`World` type:
+
+```rust
+use sage_core::ecs::World;
+
+let mut world = World::new();
+let entity = world.spawn_unit();
+```
+
+Components implementing the `Component` trait can be attached with
+`add_component` and retrieved using `get_component`.
+

--- a/agent_prio.md
+++ b/agent_prio.md
@@ -29,3 +29,37 @@
   why: Document how to compile and run the project
   depends_on: [389dcc53-5f10-4444-a7fe-2c5c9c3aca1a]
   status: [x]
+- uuid: 0404634f-46e1-4eda-9320-e1d5af984ad0
+  parent: 2e183199-ee32-469e-89e8-8a89086fc781
+  description: Add ECS module scaffolding in sage_core
+  why: Provide base types for entities and components
+  depends_on: []
+  status: [x]
+
+- uuid: ae9319e7-8714-4d44-b54b-7b33c9a95435
+  parent: 2e183199-ee32-469e-89e8-8a89086fc781
+  description: Implement entity manager with world storage
+  why: Manage entities and associated components
+  depends_on: [0404634f-46e1-4eda-9320-e1d5af984ad0]
+  status: [x]
+
+- uuid: f281dc05-b06e-4695-bb1a-f76f21266abc
+  parent: 2e183199-ee32-469e-89e8-8a89086fc781
+  description: Provide spawn_unit helper to create entities
+  why: Allows engine to instantiate units from data
+  depends_on: [ae9319e7-8714-4d44-b54b-7b33c9a95435]
+  status: [x]
+
+- uuid: dca97530-e53b-471f-8205-f83f090805d9
+  parent: 2e183199-ee32-469e-89e8-8a89086fc781
+  description: Add unit tests covering entity creation
+  why: Verify ECS works as intended
+  depends_on: [f281dc05-b06e-4695-bb1a-f76f21266abc]
+  status: [x]
+
+- uuid: 15a64eb8-3c52-4c74-99a1-61c6247728e2
+  parent: 2e183199-ee32-469e-89e8-8a89086fc781
+  description: Document ECS usage in README
+  why: Explain how to create and manage entities
+  depends_on: [dca97530-e53b-471f-8205-f83f090805d9]
+  status: [x]

--- a/agent_tasks.md
+++ b/agent_tasks.md
@@ -13,4 +13,4 @@
   why: Needed to spawn and manage units
   depends_on: [accd5429-3d72-456e-a400-82fc9c9ee308]
   priority: 2
-  status: [a]
+  status: [x]

--- a/metrics.md
+++ b/metrics.md
@@ -1,6 +1,6 @@
 # Metrics
 
-total_tasks: 6
-completed_tasks: 5
-open_tasks: 1
-critical_path: 085452b0-4b67-44e3-885c-e5eb134b8eb0
+total_tasks: 11
+completed_tasks: 11
+open_tasks: 0
+critical_path:

--- a/sage_core/src/lib.rs
+++ b/sage_core/src/lib.rs
@@ -1,3 +1,65 @@
 pub fn init() {
     println!("sage_core initialized");
 }
+
+pub mod ecs {
+    use std::any::{Any, TypeId};
+    use std::collections::HashMap;
+    /// Unique identifier for spawned entities
+    pub type EntityId = u32;
+
+    /// Basic world state tracking the next entity id
+    pub struct World {
+        next_id: EntityId,
+        storage: HashMap<EntityId, HashMap<TypeId, Box<dyn Any>>>,
+    }
+
+    impl World {
+        pub fn new() -> Self {
+            Self { next_id: 0, storage: HashMap::new() }
+        }
+
+        /// Reserve a new entity id without attaching any data yet
+        pub fn spawn(&mut self) -> EntityId {
+            let id = self.next_id;
+            self.next_id += 1;
+            self.storage.insert(id, HashMap::new());
+            id
+        }
+
+        /// Convenience wrapper used by the engine to create a basic entity
+        pub fn spawn_unit(&mut self) -> EntityId {
+            self.spawn()
+        }
+
+        /// Attach a component instance to an entity
+        pub fn add_component<C: Component>(&mut self, id: EntityId, component: C) {
+            if let Some(entry) = self.storage.get_mut(&id) {
+                entry.insert(TypeId::of::<C>(), Box::new(component));
+            }
+        }
+
+        /// Retrieve a reference to a component of an entity
+        pub fn get_component<C: Component>(&self, id: EntityId) -> Option<&C> {
+            self.storage
+                .get(&id)
+                .and_then(|m| m.get(&TypeId::of::<C>()))
+                .and_then(|b| b.downcast_ref())
+        }
+    }
+
+    /// Marker trait for components stored in the world
+    pub trait Component: 'static {}
+}
+
+#[cfg(test)]
+mod tests {
+    use super::ecs::*;
+
+    #[test]
+    fn spawn_entities_increment_id() {
+        let mut world = World::new();
+        assert_eq!(world.spawn_unit(), 0);
+        assert_eq!(world.spawn_unit(), 1);
+    }
+}

--- a/state.md
+++ b/state.md
@@ -1,6 +1,6 @@
 # Planner State
 
 graph_hash:
- 33b501689e47a8e7eed6d21c4fb9e3e21c173d3a
+ 9f165f709c1cdb48ce2882e3bf117c5bc533a657
 last_task:
 active_agents:

--- a/taskmap.svg
+++ b/taskmap.svg
@@ -15,5 +15,20 @@
   <text x="45" y="193" font-size="10">ST4 Docs</text>
 
   <rect x="250" y="20" width="180" height="30" fill="#fce5cd" stroke="#e69138" />
-  <text x="255" y="40" font-size="12">M2 ECS (planning)</text>
+  <text x="255" y="40" font-size="12">M2 ECS</text>
+
+  <rect x="270" y="70" width="160" height="25" fill="#fff2cc" stroke="#d6b656" />
+  <text x="275" y="88" font-size="10">ST5 ECS scaffold</text>
+
+  <rect x="270" y="105" width="160" height="25" fill="#fff2cc" stroke="#d6b656" />
+  <text x="275" y="123" font-size="10">ST6 Manager</text>
+
+  <rect x="270" y="140" width="160" height="25" fill="#fff2cc" stroke="#d6b656" />
+  <text x="275" y="158" font-size="10">ST7 Spawn</text>
+
+  <rect x="270" y="175" width="160" height="25" fill="#fff2cc" stroke="#d6b656" />
+  <text x="275" y="193" font-size="10">ST8 Tests</text>
+
+  <rect x="270" y="210" width="160" height="25" fill="#fff2cc" stroke="#d6b656" />
+  <text x="275" y="228" font-size="10">ST9 Docs</text>
 </svg>


### PR DESCRIPTION
## Summary
- plan Milestone 2 tasks for ECS architecture
- implement ECS world and component storage in `sage_core`
- add unit tests and README docs for ECS
- update task states, metrics, state hash and Gantt

## Testing
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_6888186f97cc832eb032de9df0424332