### PR TITLE
Plan milestone 3 for engine mapping

### DIFF
--- a/DevDiary.md
+++ b/DevDiary.md
@@ -24,3 +24,8 @@
 - Implemented ST8: added unit tests for entity creation.
 - Implemented ST9: documented ECS usage in README.
 - Milestone 2 completed: ECS can spawn and manage entities.
+
+## 2025-07-30 PlannerAgent
+- Planned Milestone 3 for generating a detailed map of the legacy engine.
+- Added five subtasks to incrementally script and produce the function map.
+- Updated manifest, metrics, state hash and taskmap accordingly.

--- a/agent_prio.md
+++ b/agent_prio.md
@@ -63,3 +63,37 @@
   why: Explain how to create and manage entities
   depends_on: [dca97530-e53b-471f-8205-f83f090805d9]
   status: [x]
+- uuid: 22f7f035-c8c4-41d4-87e4-7393fd8efdc9
+  parent: 7c9c38d0-c864-4e87-ac4f-9df7a9e7e9e5
+  description: Create engine_map script using Ctags to list functions
+  why: Automated enumeration is required to handle thousands of legacy functions
+  depends_on: []
+  status: [ ]
+
+- uuid: 651b0f03-067a-45f7-bf3c-dcccb2c9cb1b
+  parent: 7c9c38d0-c864-4e87-ac4f-9df7a9e7e9e5
+  description: Generate function list for GameLogic subsystem
+  why: First dataset segment for mapping
+  depends_on: [22f7f035-c8c4-41d4-87e4-7393fd8efdc9]
+  status: [ ]
+
+- uuid: eae6dbe3-9be8-4026-96ce-b22ead041f0c
+  parent: 7c9c38d0-c864-4e87-ac4f-9df7a9e7e9e5
+  description: Map GameClient subsystem functions
+  why: Capture rendering and UI code relationships
+  depends_on: [651b0f03-067a-45f7-bf3c-dcccb2c9cb1b]
+  status: [ ]
+
+- uuid: d782e0c1-fb67-4a02-bbab-d89d517161e4
+  parent: 7c9c38d0-c864-4e87-ac4f-9df7a9e7e9e5
+  description: Map GameNetwork subsystem functions
+  why: Document networking paths
+  depends_on: [eae6dbe3-9be8-4026-96ce-b22ead041f0c]
+  status: [ ]
+
+- uuid: 81f2de0d-07bd-41a0-9dea-509577029967
+  parent: 7c9c38d0-c864-4e87-ac4f-9df7a9e7e9e5
+  description: Consolidate data and output full function_map.md and function_graph.json
+  why: Provide complete DAG for planners and developers
+  depends_on: [d782e0c1-fb67-4a02-bbab-d89d517161e4]
+  status: [ ]

--- a/agent_tasks.md
+++ b/agent_tasks.md
@@ -14,3 +14,9 @@
   depends_on: [accd5429-3d72-456e-a400-82fc9c9ee308]
   priority: 2
   status: [x]
+- uuid: 7c9c38d0-c864-4e87-ac4f-9df7a9e7e9e5
+  description: Milestone 3 - Legacy engine function mapping
+  why: Generate a comprehensive map of the Generals Zero Hour codebase for future Rust rewrite planning
+  depends_on: [2e183199-ee32-469e-89e8-8a89086fc781]
+  priority: 3
+  status: [ ]

--- a/manifest.json
+++ b/manifest.json
@@ -24,6 +24,14 @@
         "sage_ini/Cargo.toml",
         "sage_ini/src/lib.rs"
       ]
+    },
+    {
+      "uuid": "engine_mapping",
+      "files": [
+        "scripts/engine_map.py",
+        "function_map.md",
+        "function_graph.json"
+      ]
     }
   ]
 }

--- a/metrics.md
+++ b/metrics.md
@@ -1,6 +1,6 @@
 # Metrics
 
-total_tasks: 11
+total_tasks: 17
 completed_tasks: 11
-open_tasks: 0
+open_tasks: 6
 critical_path:

--- a/state.md
+++ b/state.md
@@ -1,6 +1,6 @@
 # Planner State
 
 graph_hash:
- 9f165f709c1cdb48ce2882e3bf117c5bc533a657
+ 57f521a81c97dfa4d0fce9525524b63391be7e08
 last_task:
 active_agents:

--- a/taskmap.svg
+++ b/taskmap.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="600" height="300">
+<svg xmlns="http://www.w3.org/2000/svg" width="850" height="400">
   <rect x="20" y="20" width="160" height="30" fill="#cfe2f3" stroke="#6fa8dc" />
   <text x="25" y="40" font-size="12">M1 INI Parsing</text>
 
@@ -31,4 +31,22 @@
 
   <rect x="270" y="210" width="160" height="25" fill="#fff2cc" stroke="#d6b656" />
   <text x="275" y="228" font-size="10">ST9 Docs</text>
+
+  <rect x="480" y="20" width="220" height="30" fill="#ead1dc" stroke="#a64d79" />
+  <text x="485" y="40" font-size="12">M3 Engine Map</text>
+
+  <rect x="500" y="70" width="160" height="25" fill="#f4cccc" stroke="#a64d79" />
+  <text x="505" y="88" font-size="10">ST10 Map script</text>
+
+  <rect x="500" y="105" width="160" height="25" fill="#f4cccc" stroke="#a64d79" />
+  <text x="505" y="123" font-size="10">ST11 GameLogic</text>
+
+  <rect x="500" y="140" width="160" height="25" fill="#f4cccc" stroke="#a64d79" />
+  <text x="505" y="158" font-size="10">ST12 GameClient</text>
+
+  <rect x="500" y="175" width="160" height="25" fill="#f4cccc" stroke="#a64d79" />
+  <text x="505" y="193" font-size="10">ST13 GameNetwork</text>
+
+  <rect x="500" y="210" width="160" height="25" fill="#f4cccc" stroke="#a64d79" />
+  <text x="505" y="228" font-size="10">ST14 Consolidate</text>
 </svg>


### PR DESCRIPTION
## Summary
- add Milestone 3 for legacy engine function mapping
- plan five subtasks to build the mapping dataset
- register new artifacts in manifest
- update Gantt chart, metrics, state and dev diary

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_688987b67eb0832e9eef0a07f99b3c1f